### PR TITLE
Fix LSP process leak, Foundation hover, format deadlock, and memory

### DIFF
--- a/Sources/App/Controllers/LanguageServer.swift
+++ b/Sources/App/Controllers/LanguageServer.swift
@@ -2,6 +2,12 @@ import Foundation
 import LanguageServerProtocol
 import LanguageServerProtocolTransport
 
+#if canImport(Glibc)
+import Glibc
+#elseif canImport(Darwin)
+import Darwin
+#endif
+
 final class LanguageServer {
     let diagnosticsPublisher: @Sendable (PublishDiagnosticsNotification) -> Void
 
@@ -10,6 +16,13 @@ final class LanguageServer {
     private let serverToClient = Pipe()
 
     private var instance: LanguageServer?
+
+    /// Serializes shutdown so cleanup runs exactly once regardless of which
+    /// path (graceful reply vs. timeout) reaches it first.
+    private let stopQueue = DispatchQueue(label: "languageserver.stop")
+    private var stopped = false
+    /// How long to wait for a graceful LSP shutdown before force-killing.
+    private let shutdownTimeout: TimeInterval = 3
 
     private let serverPath: String?
 
@@ -56,9 +69,33 @@ final class LanguageServer {
     }
 
     func stop() {
+        // Attempt a graceful LSP shutdown, but never depend on its reply for
+        // cleanup: if sourcekit-lsp is hung or the connection is already broken
+        // the completion handler may never fire. A timeout guarantees the
+        // process is reaped and the self-retain (`instance`) is released so we
+        // don't leak a sourcekit-lsp process (and its memory) per session.
         sendShutdownRequest { [weak self] _ in
-            self?.sendExitNotification()
-            self?.instance = nil
+            self?.terminate()
+        }
+        stopQueue.asyncAfter(deadline: .now() + shutdownTimeout) { [weak self] in
+            self?.terminate()
+        }
+    }
+
+    /// Idempotent, force cleanup. Safe to call multiple times and from any
+    /// thread; the actual work runs once on `stopQueue`.
+    private func terminate() {
+        stopQueue.async { [weak self] in
+            guard let self, !self.stopped else { return }
+            self.stopped = true
+            if self.serverProcess.isRunning {
+                // SIGKILL rather than terminate()/SIGTERM: a hung sourcekit-lsp
+                // may ignore SIGTERM. The workspace is ephemeral so there is no
+                // state to flush.
+                kill(self.serverProcess.processIdentifier, SIGKILL)
+            }
+            self.connection.close()
+            self.instance = nil
         }
     }
 
@@ -67,6 +104,13 @@ final class LanguageServer {
 
         let request = InitializeRequest(
             rootURI: DocumentURI(rootURI),
+            // Disable background indexing (default is on). Each connection gets
+            // its own throwaway single-file workspace, so project-wide indexing
+            // is wasted work; it spawns swift-frontend processes and causes the
+            // memory spikes that trip the container's OOM limit. Hover/
+            // completion come from sourcekitd cursor-info, not the index store,
+            // so they are unaffected. (Must precede `capabilities` in the init.)
+            initializationOptions: .dictionary(["backgroundIndexing": .bool(false)]),
             capabilities: ClientCapabilities(
                 textDocument: TextDocumentClientCapabilities(
                     completion: TextDocumentClientCapabilities.Completion(
@@ -194,11 +238,6 @@ final class LanguageServer {
         _ = connection.send(request) {
             completion($0)
         }
-    }
-
-    func sendExitNotification() {
-        connection.send(ExitNotification())
-        serverProcess.terminate()
     }
 }
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -261,8 +261,12 @@ func routes(_ app: Application) throws {
         // swift-format reads stdin to EOF before emitting output, so this write
         // is drained concurrently by the child and cannot deadlock.
         standardInput.fileHandleForWriting.write(input)
-        try? standardInput.fileHandleForWriting.close()
-
+        do {
+            try standardInput.fileHandleForWriting.close()
+        } catch {
+            process.terminate()
+            return source
+        }
         // Read stdout to EOF *before* waitUntilExit(). Reading afterwards
         // deadlocks once the output exceeds the pipe buffer: the child blocks
         // writing stdout while we block waiting for it to exit.

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -10,7 +10,10 @@ func routes(_ app: Application) throws {
 
     func healthCheck() -> [String: String] { ["status": "pass"] }
 
-    app.webSocket("lang-server", "api") { (req, ws) in
+    // Raise the inbound frame limit from Vapor's 16KB default. Source larger
+    // than that (didOpen/didChange/format) otherwise trips a 1009
+    // "Message Too Big" close, disconnecting the user mid-edit.
+    app.webSocket("lang-server", "api", maxFrameSize: .init(integerLiteral: 1 << 20)) { (req, ws) in
         languageServer(req, ws)
     }
 
@@ -139,6 +142,11 @@ func routes(_ app: Application) throws {
                 languageServer?.sendInitializeRequest(workspacePath: workspacePath) { [weak languageServer] (result) in
                     switch result {
                     case .success:
+                        // The LSP spec requires `initialized` after the initialize
+                        // response. sourcekit-lsp defers build-server / module
+                        // setup until it receives this, which is needed for
+                        // cross-module hover (e.g. Foundation symbols).
+                        languageServer?.sendInitializedNotification()
                         languageServer?.sendDidOpenNotification(documentPath: documentPath, text: request.code)
                     case .failure:
                         break
@@ -201,11 +209,16 @@ func routes(_ app: Application) throws {
             case _ where text.hasPrefix(#"{"method":"format""#):
                 guard let request = try? decoder.decode(FormatRequest.self, from: data) else { return }
                 let source = request.code
-                let output = format(source: source)
-                let formatResponse = FormatResponse(method: "format", value: output)
-                guard let data = try? encoder.encode(formatResponse) else { return }
-                guard let json = String(data: data, encoding: .utf8) else { return }
-                ws.send(json)
+                // swift-format is a synchronous subprocess. Run it off the
+                // NIO event loop so it can't stall this (and every other)
+                // connection sharing the loop.
+                DispatchQueue.global().async {
+                    let output = format(source: source)
+                    let formatResponse = FormatResponse(method: "format", value: output)
+                    guard let data = try? encoder.encode(formatResponse) else { return }
+                    guard let json = String(data: data, encoding: .utf8) else { return }
+                    ws.send(json)
+                }
             default:
                 break
             }
@@ -221,14 +234,6 @@ func routes(_ app: Application) throws {
         let standardOutput = Pipe()
         let standardError = Pipe()
 
-        let fileHandle = standardInput.fileHandleForWriting
-        fileHandle.write(input)
-        do {
-            try fileHandle.close()
-        } catch {
-            return source
-        }
-
         let process = Process()
         let executableURL = URL(
             fileURLWithPath: app.directory.resourcesDirectory
@@ -240,11 +245,30 @@ func routes(_ app: Application) throws {
         process.standardOutput = standardOutput
         process.standardError = standardError
 
-        process.launch()
+        do {
+            try process.run()
+        } catch {
+            return source
+        }
+
+        // Drain stderr in the background so it can't fill its pipe buffer
+        // (~64KB) and block the child.
+        DispatchQueue.global().async {
+            _ = standardError.fileHandleForReading.readDataToEndOfFile()
+        }
+
+        // swift-format reads stdin to EOF before emitting output, so this write
+        // is drained concurrently by the child and cannot deadlock.
+        standardInput.fileHandleForWriting.write(input)
+        try? standardInput.fileHandleForWriting.close()
+
+        // Read stdout to EOF *before* waitUntilExit(). Reading afterwards
+        // deadlocks once the output exceeds the pipe buffer: the child blocks
+        // writing stdout while we block waiting for it to exit.
+        let outputData = standardOutput.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
 
-        let data = standardOutput.fileHandleForReading.readDataToEndOfFile()
-        guard let output = String(data: data, encoding: .utf8) else {
+        guard let output = String(data: outputData, encoding: .utf8) else {
             return source
         }
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -215,6 +215,7 @@ func routes(_ app: Application) throws {
                 DispatchQueue.global().async {
                     let output = format(source: source)
                     let formatResponse = FormatResponse(method: "format", value: output)
+                    let encoder = JSONEncoder()
                     guard let data = try? encoder.encode(formatResponse) else { return }
                     guard let json = String(data: data, encoding: .utf8) else { return }
                     ws.send(json)


### PR DESCRIPTION
Five fixes to the language-server WebSocket bridge, each verified against a locally rebuilt Docker image.

## Changes

### 1. Restore Foundation hover — send `initialized` (`routes.swift`)
The handler sent `initialize` then `didOpen` but never the required `initialized` notification. Newer sourcekit-lsp defers build-server / module setup until it receives `initialized`, so cross-module hover (Foundation symbols like `Date`, `URL`, `String.uppercased()`) returned nothing while stdlib hover (`print`) still worked.
**Verified:** `Date` → `struct Date : Comparable…`, `uppercased` → ✅, `print` → ✅.

### 2. Reap sourcekit-lsp on disconnect — fix the memory/process leak (`LanguageServer.swift`)
`stop()` only terminated the process inside the shutdown-reply completion handler, which **never fires** when sourcekit-lsp is hung or the connection is already broken — leaking a sourcekit-lsp process (≈0.5–1GB) and the `ws`/pipes per session. A 3s timeout now guarantees a `SIGKILL` and releases the self-retain, run exactly once on a serial queue.
**Verified:** 6 abrupt-close sessions → 0 leftover processes, 0 leftover `/tmp` workspaces, memory back to baseline.

### 3. `format()` — run off the event loop + fix pipe-buffer deadlock (`routes.swift`)
swift-format ran synchronously on the NIO event loop (stalling every connection on that loop), and read stdout only *after* `waitUntilExit()` — a deadlock once output exceeds the ~64KB pipe buffer. Now dispatched off-loop; stdout drained before waiting, stderr drained in the background; deprecated `launch()` → `try run()`.
**Verified:** format returns in ~0.02s and the connection stays responsive (hover works immediately after).

### 4. Disable background indexing (`LanguageServer.swift`)
Each connection gets a throwaway single-file workspace, so project-wide background indexing is wasted work that spawns `swift-frontend` processes and drives the memory spikes behind the container OOM. Disabled via `initializationOptions: {"backgroundIndexing": false}`. Hover/completion use sourcekitd cursor-info, so they're unaffected.
**Verified:** 4 concurrent sessions spawn only 4 `sourcekit-lsp` processes and **zero** `swift-frontend` (vs. up to 16 processes before); Foundation hover still works.

### 5. Raise WebSocket frame limit 16KB → 1MB (`routes.swift`)
Source over Vapor's 16KB default `maxFrameSize` tripped a `1009` "Message Too Big" close, disconnecting users editing larger files.
**Verified:** 20KB–300KB messages now accepted (previously closed with 1009).

## Follow-up (not in this PR)
- Pin `sourcekit-lsp` off `branch: "main"` to a release matching the Swift toolchain — the moving dependency is what let the Foundation-hover regression appear without a code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)