### PR TITLE
Add signatureHelp (parameter hints) to the LSP WebSocket API

### DIFF
--- a/Sources/App/Controllers/LanguageServer.swift
+++ b/Sources/App/Controllers/LanguageServer.swift
@@ -196,6 +196,18 @@ final class LanguageServer {
         }
     }
 
+    func sendSignatureHelpRequest(documentPath: String, line: Int, character: Int, completion: @escaping (Result<SignatureHelpRequest.Response, ResponseError>) -> Void) {
+        let identifier = URL(fileURLWithPath: documentPath)
+
+        let signatureHelpRequest = SignatureHelpRequest(
+            textDocument: TextDocumentIdentifier(DocumentURI(identifier)),
+            position: Position(line: line, utf16index: character)
+        )
+        _ = connection.send(signatureHelpRequest) {
+            completion($0)
+        }
+    }
+
     func sendDefinitionRequest(documentPath: String, line: Int, character: Int, completion: @escaping (Result<DefinitionRequest.Response, ResponseError>) -> Void) {
         let identifier = URL(fileURLWithPath: documentPath)
 

--- a/Sources/App/routes.swift
+++ b/Sources/App/routes.swift
@@ -53,6 +53,13 @@ func routes(_ app: Application) throws {
             let value: LanguageServerProtocol.CompletionRequest.Response?
         }
 
+        typealias SignatureHelpRequestMessage = HoverRequest
+        struct SignatureHelpResponse: Codable {
+            let method: String
+            let id: Int
+            let value: LanguageServerProtocol.SignatureHelpRequest.Response
+        }
+
         struct DiagnosticsNotification: Codable {
             let method: String
             let value: PublishDiagnosticsNotification
@@ -203,6 +210,27 @@ func routes(_ app: Application) throws {
                         value: value
                     )
                     guard let data = try? encoder.encode(completionResponse) else { return }
+                    guard let json = String(data: data, encoding: .utf8) else { return }
+                    ws.send(json)
+                }
+            case _ where text.hasPrefix(#"{"method":"signatureHelp""#):
+                guard let request = try? decoder.decode(SignatureHelpRequestMessage.self, from: data) else { return }
+                languageServer?.sendSignatureHelpRequest(
+                    documentPath: documentPath, line: request.row, character: request.column
+                ) { (result) in
+                    let value: LanguageServerProtocol.SignatureHelpRequest.Response
+                    switch result {
+                    case .success(let response):
+                        value = response
+                    case .failure:
+                        value = nil
+                    }
+                    let signatureHelpResponse = SignatureHelpResponse(
+                        method: "signatureHelp",
+                        id: request.id,
+                        value: value
+                    )
+                    guard let data = try? encoder.encode(signatureHelpResponse) else { return }
                     guard let json = String(data: data, encoding: .utf8) else { return }
                     ws.send(json)
                 }


### PR DESCRIPTION
Exposes `textDocument/signatureHelp` over the WebSocket bridge so the editor can show Xcode-style parameter hints.

sourcekit-lsp on `main` now implements signature help (`SwiftLanguageService/SignatureHelp.swift`), so this just wires it through:

- `LanguageServer.sendSignatureHelpRequest(documentPath:line:character:)` issues `textDocument/signatureHelp`.
- `routes.swift` handles a new `signatureHelp` WebSocket method and returns `{ method, id, value }` where `value` is the LSP `SignatureHelp` (signatures / parameters / activeParameter).

**Verified** end-to-end against a locally rebuilt image: for `greet(name: String, times: Int)`, requesting signature help inside the call returns the signature label and parameter ranges, and `activeParameter` correctly advances from `0` to `1` as the cursor moves past the comma.

The companion frontend change (Monaco `registerSignatureHelpProvider` + the `signatureHelp` request, plus completion-trigger improvements) is in SwiftFiddle/swiftfiddle-web#1234.

> Supersedes #357, which GitHub auto-closed when its stacked base branch was deleted on merge of #356. Same commit, now based directly on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)